### PR TITLE
Propose a way of precomputing embeddings using a fragmented cache

### DIFF
--- a/data_utils.py
+++ b/data_utils.py
@@ -129,3 +129,8 @@ def flatmap(iterable):
         A list that is flattened by one-level
     """
     return list(chain.from_iterable(iterable))
+
+
+def chunks(data, n):
+    for i in range(0, len(data), n):
+        yield data[i:i + n]

--- a/models/bert_feature_extractor_model.py
+++ b/models/bert_feature_extractor_model.py
@@ -1,15 +1,18 @@
 import enum
 import torch
+import uuid
 from pathlib import Path
 from torch import nn, Tensor
 from typing import List, Callable
 from transformers import AutoTokenizer, AutoModel, AutoConfig
 from loggers import getLogger
 import pickle
+
 logger = getLogger(__name__)
 
-CACHE_PATH = Path(__file__).parents[0] / "bert-cache"
+CACHE_PATH = Path(__file__).parents[0] / "embeddings-cache"
 CACHE_PATH.mkdir(parents=True, exist_ok=True)
+
 
 class BERTVersion(enum.Enum):
     """
@@ -26,37 +29,42 @@ def average_axis(axis: int, tensor: Tensor) -> Tensor:
     return tensor.sum(axis) / tensor.shape[axis]
 
 
+def memory_report():
+    return
+    print(torch.cuda.memory_stats(0)['reserved_bytes.all.current'] / 1024 / 1024, "MB")
+    print(torch.cuda.memory_stats(0)['allocated_bytes.all.current'] / 1024 / 1024, "MB")
+
+
 class BERTAsFeatureExtractorEncoder(nn.Module):
     def __init__(
-        self,
-        bert_version: BERTVersion,
-        hidden_size: int = None,
-        bert_reducer: Callable[[Tensor], Tensor] = average_layers_and_tokens
+            self,
+            bert_version: BERTVersion,
+            hidden_size: int = None,
+            bert_reducer: Callable[[Tensor], Tensor] = average_layers_and_tokens,
+            device=None
     ):
         super().__init__()
+        self.device = device
+        if not self.device:
+            self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
         self.bert_version = bert_version.value
         self.bert_reducer = bert_reducer
         self.config = AutoConfig.from_pretrained(self.bert_version, output_hidden_states=True, return_dict=True)
         self.tokenizer = AutoTokenizer.from_pretrained(self.bert_version, config=self.config)
         self.bert = AutoModel.from_pretrained(self.bert_version, config=self.config)
+        self.bert.to('cuda')
         self.embeddings_dim = self.config.hidden_size
         self.hidden_size = hidden_size or self.embeddings_dim * 2
 
         self.linear = nn.Linear(self.embeddings_dim, self.hidden_size)
-        self.cached_embeddings = {}
-        self.cached_path = CACHE_PATH / ("%s.cache" % bert_version.value)
-        try:
-            with self.cached_path.open('rb') as cachefile:
-                self.cached_embeddings = pickle.load(cachefile)
-                logger.info("Cached BERT loaded from %s", self.cached_path)
-        except Exception as e:
-            logger.warn("Cached BERT embeddings from %s cannot be loaded (%s)", self.cached_path, e)
-
+        self.cache = EmbeddingsCache(bert_version.value)
 
     def forward(self, documents: List[str]) -> Tensor:
-        embeddings = self.compute_embeddings(documents)
-        return self.linear(embeddings)
+        embeddings = self.compute_embeddings(documents) + 0.1
+        memory_report()
+        retval = self.linear(embeddings)
+        return retval
 
     def compute_embeddings(self, documents: List[str]) -> Tensor:
         """
@@ -84,35 +92,83 @@ class BERTAsFeatureExtractorEncoder(nn.Module):
         >>> torch.mean(out2[1])
         tensor(-0.0187)
         """
-        hits = []
-        misses = []
-        for doc in documents:
-            if doc in self.cached_embeddings:
-                hits.append(self.cached_embeddings[doc])
-            else:
-                hits.append(None)
-                misses.append(doc)
+        results, misses = self.cache.get_many(documents)
 
         nb_misses = len(misses)
         if nb_misses:
-            logger.debug("Computing BERT embeddings for %d cache misses (%d hits)", nb_misses, len(hits) - nb_misses)
-            with torch.no_grad():
-                inputs = self.tokenizer(misses, return_tensors="pt", padding=True, truncation=True)
-                hidden_states = self.bert(**inputs).hidden_states
-                embeddings = self.bert_reducer(torch.stack(hidden_states))
+            logger.debug("Computing BERT embeddings for %d cache misses (%d hits)", nb_misses, len(results) - nb_misses)
+            embeddings = self.bert_reducer(self._run_bert(documents))
             idx = 0
-            for i, doc in enumerate(hits):
+            for i, doc in enumerate(results):
                 if doc is None:
-                    array = embeddings[idx].numpy()
-                    hits[i] = self.cached_embeddings[misses[idx]] = array
+                    results[i] = embeddings[idx]
+                    self.cache[misses[idx]] = embeddings[idx].tolist()
                     idx += 1
 
-            with self.cached_path.open('wb') as cachefile:
-                pickle.dump(self.cached_embeddings, cachefile)
+        retval = torch.stack([Tensor(hit) for hit in results])
+        return retval
 
-        return torch.stack([torch.from_numpy(hit) for hit in hits])
+    def _run_bert(self, documents):
+        with torch.no_grad():
+            encoded_chunks = []
+            for chunk in chunks(documents, 1000):
+                inputs = self.tokenizer(chunk, return_tensors="pt", padding=True, truncation=True).to('cuda')
+                hidden_states = self.bert(**inputs).hidden_states
+                encoded_chunks.append(torch.stack([s.to('cpu') for s in hidden_states]))
+            return torch.stack(encoded_chunks)
+
+
+class EmbeddingsCache(dict):
+
+    def __init__(self, name, *args, **kwargs):
+        super(EmbeddingsCache, self).__init__(*args, **kwargs)
+        self.cache_path = CACHE_PATH / name
+        self.unsaved_keys = []
+        logger.info("Loading cached embeddings from %s", self.cache_path)
+        try:
+            for i, path in enumerate(self.cache_path.glob('*.pickle')):
+                with path.open('rb') as cachefile:
+                    self.update(pickle.load(cachefile))
+            logger.info("%d cached embeddings loaded from %d files", len(self), i + 1)
+        except Exception as e:
+            logger.warn("Cached BERT embeddings from %s cannot be loaded (%s)", self.cache_path, e)
+
+    def get_many(self, documents):
+        hits = []
+        misses = []
+        for doc in documents:
+            if doc in self:
+                hits.append(self[doc])
+            else:
+                hits.append(None)
+                misses.append(doc)
+        return hits, misses
+
+    def __setitem__(self, key, value):
+        if key not in self:
+            self.unsaved_keys.append(key)
+        super(EmbeddingsCache, self).__setitem__(key, value)
+        if len(self.unsaved_keys) > 10000:
+            self.save()
+
+    def save(self):
+        nb_items = len(self.unsaved_keys)
+        logger.debug("Saving %d embeddings", nb_items)
+        new_path = self.cache_path / "{0}.pickle".format(uuid.uuid4())
+        with new_path.open('wb') as cachefile:
+            tmp_dict = {k: self[k] for k in self.unsaved_keys}
+            pickle.dump(tmp_dict, cachefile)
+            self.unsaved_keys = []
+        logger.debug("Saved %d embeddings", nb_items)
+
+
+def chunks(lst, n):
+    """Yield successive n-sized chunks from lst."""
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]
 
 
 if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/models/bert_feature_extractor_model.py
+++ b/models/bert_feature_extractor_model.py
@@ -29,12 +29,6 @@ def average_axis(axis: int, tensor: Tensor) -> Tensor:
     return tensor.sum(axis) / tensor.shape[axis]
 
 
-def memory_report():
-    return
-    print(torch.cuda.memory_stats(0)['reserved_bytes.all.current'] / 1024 / 1024, "MB")
-    print(torch.cuda.memory_stats(0)['allocated_bytes.all.current'] / 1024 / 1024, "MB")
-
-
 class BERTAsFeatureExtractorEncoder(nn.Module):
     def __init__(
             self,

--- a/models/bert_feature_extractor_model.py
+++ b/models/bert_feature_extractor_model.py
@@ -46,7 +46,7 @@ class BERTAsFeatureExtractorEncoder(nn.Module):
         self.embeddings_dim = self.config.hidden_size
         self.hidden_size = hidden_size or self.embeddings_dim * 2
 
-        self.linear = nn.Linear(self.embeddings_dim, self.hidden_size)
+        self.linear = nn.Linear(self.embeddings_dim, self.hidden_size).to(self.device)
         self.cache = EmbeddingsCache(bert_version.value)
 
     def forward(self, documents: List[str]) -> Tensor:

--- a/models/bert_feature_extractor_model.py
+++ b/models/bert_feature_extractor_model.py
@@ -56,7 +56,6 @@ class BERTAsFeatureExtractorEncoder(nn.Module):
 
     def forward(self, documents: List[str]) -> Tensor:
         embeddings = self.compute_embeddings(documents) + 0.1
-        memory_report()
         retval = self.linear(embeddings)
         return retval
 

--- a/models/bert_feature_extractor_model.py
+++ b/models/bert_feature_extractor_model.py
@@ -55,9 +55,8 @@ class BERTAsFeatureExtractorEncoder(nn.Module):
         self.cache = EmbeddingsCache(bert_version.value)
 
     def forward(self, documents: List[str]) -> Tensor:
-        embeddings = self.compute_embeddings(documents) + 0.1
-        retval = self.linear(embeddings)
-        return retval
+        embeddings = self.compute_embeddings(documents)
+        return self.linear(embeddings)
 
     def compute_embeddings(self, documents: List[str]) -> Tensor:
         """

--- a/models/utils.py
+++ b/models/utils.py
@@ -1,0 +1,53 @@
+import uuid
+import pickle
+from pathlib import Path
+from loggers import getLogger
+
+CACHE_PATH = Path(__file__).parents[0] / "embeddings-cache"
+CACHE_PATH.mkdir(parents=True, exist_ok=True)
+
+logger = getLogger(__name__)
+
+class EmbeddingsCache(dict):
+
+    def __init__(self, name, *args, **kwargs):
+        super(EmbeddingsCache, self).__init__(*args, **kwargs)
+        self.cache_path = CACHE_PATH / name
+        self.unsaved_keys = []
+        logger.info("Loading cached embeddings from %s", self.cache_path)
+        try:
+            for i, path in enumerate(self.cache_path.glob('*.pickle')):
+                with path.open('rb') as cachefile:
+                    self.update(pickle.load(cachefile))
+            logger.info("%d cached embeddings loaded from %d files", len(self), i + 1)
+        except Exception as e:
+            logger.warn("Cached BERT embeddings from %s cannot be loaded (%s)", self.cache_path, e)
+
+    def get_many(self, documents):
+        hits = []
+        misses = []
+        for doc in documents:
+            if doc in self:
+                hits.append(self[doc])
+            else:
+                hits.append(None)
+                misses.append(doc)
+        return hits, misses
+
+    def __setitem__(self, key, value):
+        if key not in self:
+            self.unsaved_keys.append(key)
+        super(EmbeddingsCache, self).__setitem__(key, value)
+        if len(self.unsaved_keys) > 10000:
+            self.save()
+
+    def save(self):
+        nb_items = len(self.unsaved_keys)
+        logger.debug("Saving %d embeddings", nb_items)
+        new_path = self.cache_path / "{0}.pickle".format(uuid.uuid4())
+        with new_path.open('wb') as cachefile:
+            tmp_dict = {k: self[k] for k in self.unsaved_keys}
+            pickle.dump(tmp_dict, cachefile)
+            self.unsaved_keys = []
+        logger.debug("Saved %d embeddings", nb_items)
+


### PR DESCRIPTION
This PR adds `precompute-embeddings` command that makes it possible to cache all the embeddings first, and train only once they're available:

```bash
$ python train.py precompute-embeddings --model_type=bert_avg_layer_token_feature_extractor --batch_size=1000
```